### PR TITLE
Moved the record status text to the top of the record view, altered t…

### DIFF
--- a/web-ui/src/main/resources/catalog/style/gn.less
+++ b/web-ui/src/main/resources/catalog/style/gn.less
@@ -105,8 +105,8 @@ div[gn-transfer-ownership] * .list-group {
   z-index: 5;
 }
 
-// Simon: remove the position: fixed; and padding-top: 120px; so that we can have 
-// a top banner logo 
+// Simon: remove the position: fixed; and padding-top: 120px; so that we can have
+// a top banner logo
 [ng-app="gn_editor"] {
   .gn-top-bar {
     //position: fixed;
@@ -598,13 +598,8 @@ i.fa-times.delete:hover {
   .gn-status {
     border: 2px solid darken(@brand-info, 5%);
     position: absolute;
-    top: 95px;
-    left: 2px;
     border-radius: 6px;
     padding: 2px;
-    -ms-transform: rotate(-30deg);
-    -webkit-transform: rotate(-30deg);
-    transform: rotate(-30deg);
     color: @brand-info;
     font-weight: bold;
     font-size: 80%;
@@ -613,9 +608,9 @@ i.fa-times.delete:hover {
   .gn-status-mdview {
     font-size: 110%;
     position: relative;
+    margin-top: 30px;
+    margin-bottom: 30px;
     float: right;
-    top: -52px;
-    margin-right: -20px;
   }
   /* Decide here which status should be displayed
   or not and with which colors */

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView.html
@@ -124,11 +124,32 @@
     <div data-ng-show="!usingFormatter" class="gn-metadata-display">
 
       <div class="col-md-8 gn-record">
-        <h1>
-          <i class="fa gn-icon-{{mdView.current.record.type[0]}}"/>
-          {{mdView.current.record.title || mdView.current.record.defaultTitle}}
+        <div data-ng-if="mdView.current.record.status_text.length > 0 && mdView.current.record.status_text[0] != 'Completed'">
+          <div class="row">
+            <div class="col-md-10" style="padding:0">
+              <h1>
+                <i class="fa gn-icon-{{mdView.current.record.type[0]}}"/>
+                {{mdView.current.record.title.trim() || mdView.current.record.defaultTitle}}
+              </h1>
+            </div>
+            <div class="col-md-2" style="padding:0">
+              <!-- Display the first metadata status (apply to ISO19139 record) -->
+              <div data-ng-if="mdView.current.record.status_text.length > 0"
+                   title="{{mdView.current.record.status_text[0]}}"
+                   class="gn-status gn-status-mdview gn-status-{{mdView.current.record.status[0]}}">
+                {{mdView.current.record.status_text[0]}}
+              </div>
+            </div>
+          </div>
+        </div>
 
-        </h1>
+        <div data-ng-if="mdView.current.record.status_text.length == 0 || mdView.current.record.status_text[0] == 'Completed'">
+          <h1>
+            <i class="fa gn-icon-{{mdView.current.record.type[0]}}"/>
+            {{mdView.current.record.title || mdView.current.record.defaultTitle}}
+          </h1>
+        </div>
+
         <h2     class="text-warning"
                 data-ng-show="mdView.current.record.draft == 'Y'"
                 data-translate="">Working Copy</h2>
@@ -136,12 +157,6 @@
         <div class="alert alert-info"
              data-ng-bind-html="(mdView.current.record.abstract || mdView.current.record.defaultAbstract) | linky | newlines"/>
 
-        <!-- Display the first metadata status (apply to ISO19139 record) -->
-        <div data-ng-if="mdView.current.record.status_text.length > 0"
-             title="{{mdView.current.record.status_text[0]}}"
-             class="gn-status gn-status-mdview gn-status-{{mdView.current.record.status[0]}}">
-          {{mdView.current.record.status_text[0]}}
-        </div>
         <div data-gn-related-observer>
           <div data-gn-related="mdView.current.record"
                data-user="user"


### PR DESCRIPTION
…he style, removed the funky rotation. Record status tags should only show when the status text is not 'Completed'. I've added some style tags to the markup where there was no previous css class - not sure if this is the way we want to do it. Also, I noticed an issue with record titles that don't have a gn-icon having a space at the start of the title caused by a carriage return in the markup.