### PR TITLE
Changing distribution format label in editor

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/loc/eng/labels.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/eng/labels.xml
@@ -1045,7 +1045,7 @@
     </helper>
   </element>
   <element name="gmd:distributionFormat" id="271.0">
-    <label>Distribution format</label>
+    <label>Distribution Format</label>
     <condition>mandatory</condition>
     <description>Provides a description of the format of the data to be
       distributed

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/tur/labels.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/tur/labels.xml
@@ -1020,7 +1020,7 @@
     </helper>
   </element>
   <element name="gmd:distributionFormat" id="271.0">
-    <label>Distribution format</label>
+    <label>Distribution Format</label>
     <condition>mandatory</condition>
     <description>Provides a description of the format of the data to be
       distributed


### PR DESCRIPTION
I made the label changes in all the obvious places. There were a number of changes to the XML files in the schemas directory. I recall they are managed by their own git repos so will look to commit to them soon.