### PR TITLE
Marlin 448 change editor and viewer temporal labels and format

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ sudo ./bin/start-dev-swarm.sh
 This requires a Traefik edge router to be running. To view the container output, follow the Docker logs with:
 
 ```shell script
-sudo docker service logs geonetwork_jetty -f
+sudo docker service logs geonetwork_jetty -f --since 2m
 ```
 
 To access the application, go to: [geonetwork.localhost/geonetwork](geonetwork.localhost/geonetwork)

--- a/web-ui/src/main/resources/catalog/templates/editor/top-toolbar.html
+++ b/web-ui/src/main/resources/catalog/templates/editor/top-toolbar.html
@@ -4,7 +4,7 @@
 
   <p class="navbar-text gn-tooltip"
      data-ng-mouseover="getSaveStatus()" title="{{savedStatus}}">
-    <span data-ng-class="saveError ? 'text-danger' : ''">{{savedStatus}}</span><br/>
+    <span data-ng-class="saveError ? 'text-danger' : ''">{{savedStatus}}</span>
     <strong title="{{gnCurrentEdit.mdTitle}}">
       {{gnCurrentEdit.mdTitle | limitTo: 50 }}
       {{gnCurrentEdit.mdTitle.length > 50 ? '...' : ''}}
@@ -28,7 +28,7 @@
     <div data-gn-metadata-group-updater="groupOwner"
          data-metadata-id="gnCurrentEdit.id" title="{{'group'|translate}}"/>
 
-    <!-- Remove versioning - if we have it on we will 
+    <!-- Remove versioning - if we have it on we will
          do it elsewhere -->
     <!--
     <div class="btn-group">

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView.html
@@ -519,28 +519,30 @@
             <dt data-translate>creationDate</dt>
             <dd data-ng-repeat="creaDate in mdView.current.record.creationDate track by $index"
                 data-gn-humanize-time="{{creaDate}}"
-                data-format="YYYY-MM-DD"/>
+                data-format="Do MMM YYYY"/>
           </dl>
           <dl data-ng-show="mdView.current.record.publicationDate.length > 0">
             <dt data-translate>publicationDate</dt>
             <dd data-ng-repeat="pubDate in mdView.current.record.publicationDate track by $index"
                 data-gn-humanize-time="{{pubDate}}"
-                data-format="YYYY-MM-DD"/>
+                data-format="Do MMM YYYY"/>
           </dl>
           <dl data-ng-show="mdView.current.record.revisionDate.length > 0">
             <dt data-translate>revisionDate</dt>
             <dd data-ng-repeat="revDate in mdView.current.record.revisionDate track by $index"
                 data-gn-humanize-time="{{revDate}}"
-                data-format="YYYY-MM-DD"/>
+                data-format="Do MMM YYYY"/>
           </dl>
           <dl
             data-ng-show="mdView.current.record.tempExtentBegin ||
                               mdView.current.record.tempExtentEnd">
             <dt data-translate>tempExtentBegin</dt>
             <dd>
-              <span data-gn-humanize-time="{{mdView.current.record.tempExtentBegin}}"/>
+              <span data-gn-humanize-time="{{mdView.current.record.tempExtentBegin}}"
+                    data-format="Do MMM YYYY"/>
               &nbsp;<i class="fa fa-fw fa-forward"></i>
-              <span data-gn-humanize-time="{{mdView.current.record.tempExtentEnd}}"/>
+              <span data-gn-humanize-time="{{mdView.current.record.tempExtentEnd}}"
+                    data-format="Do MMM YYYY"/>
             </dd>
           </dl>
           </p>


### PR DESCRIPTION
Modified human readable dates in metadata viewer and fixed metadata record title spacing in editor. Label change in schema committed to ISO 19115-3 repo on the 3.4.x branch.